### PR TITLE
chore: upload releases yaml config to cdn for installer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
       PRE_RELEASE_TAG: vmain
       ZIP_NAME: hs-b787-9-${{ github.ref_name }}.zip
       BUILD_DIR_NAME: main
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/horizonsim-789/development
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -55,11 +57,20 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME }} ./horizonsim-aircraft-787-9/
           cd ../../
       - name: Upload to Cloudflare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/horizonsim-789/development
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./horizonsim-789/build/build-modules
+      - name: Get short SHA
+        uses: benjlevesque/short-sha@v2.2
+        id: short-sha
+      - name: Upload Release Config to CloudFlare CDN
+        env:
+          SHA: ${{ steps.short-sha.outputs.sha }}
+        run: |
+          mkdir -p ./horizonsim-789/build/config
+          echo "releases:" >> ./horizonsim-789/build/config/releases.yaml
+          echo "  - name: $SHA" >> ./horizonsim-789/build/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./horizonsim-789/build/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./horizonsim-789/build/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
       PRE_RELEASE_TAG: vstable
       ZIP_NAME: hs-b787-9-${{ github.ref_name }}.zip
       BUILD_DIR_NAME: stable
+      CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
+      CDN_BUCKET_DESTINATION: addons/horizonsim-789/release
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -59,11 +61,15 @@ jobs:
           zip -r ../../${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME }} ./horizonsim-aircraft-787-9/
           cd ../../
       - name: Upload to Cloudflare CDN
-        env:
-          CLOUDFLARE_WORKER_PASSWORD: ${{ secrets.CLOUDFLARE_WORKER_PASSWORD }}
-          CDN_BUCKET_DESTINATION: addons/horizonsim-789/release
         run: |
           ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./horizonsim-789/build/build-modules
+      - name: Upload Release Config to CloudFlare CDN
+        run: |
+          mkdir -p ./horizonsim-789/build/config
+          echo "releases:" >> ./horizonsim-789/build/config/releases.yaml
+          echo "  - name: $GITHUB_REF_NAME" >> ./horizonsim-789/build/config/releases.yaml
+          echo "    date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ./horizonsim-789/build/config/releases.yaml
+          ./scripts/cdn.sh $CDN_BUCKET_DESTINATION ./horizonsim-789/build/config
       - name: Upload to Google Drive
         uses: adityak74/google-drive-upload-git-action@main
         with:


### PR DESCRIPTION
Create a `releases.yaml` file which will be used by the headwind installer for information to make github api request call obsolete / minimize them.